### PR TITLE
Create missing directories.

### DIFF
--- a/prepare_env/tasks/prepare_env.yml
+++ b/prepare_env/tasks/prepare_env.yml
@@ -6,6 +6,16 @@
     path={{ temp_dir }}
     state=directory
 
+- name: create software dir
+  file:
+    path={{ local_soft_dir }}
+    state=directory
+
+- name: create binary dir
+  file:
+    path={{ local_bin_dir }}
+    state=directory
+
 - name: Set vm.swappiness
   sysctl: >
     name=vm.swappiness


### PR DESCRIPTION
These directories are never created by any roles. On the fresh machine, tasks which using these directories return e.g. `"dest '/home/k0chan/bin' must be an existing dir"`